### PR TITLE
remove python2-pip from bootstrap requirements

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -15,7 +15,7 @@ if [ -f /etc/debian_version ]; then
     fi
 fi
 if [ -f /etc/redhat-release ]; then
-    for package in python2-pip python-virtualenv python-devel libevent-devel; do
+    for package in python-virtualenv python-devel libevent-devel; do
         if [ "$(rpm -qa $package 2>/dev/null)" == "" ]; then
             missing="${missing:+$missing }$package"
         fi


### PR DESCRIPTION
Similar to: https://github.com/ceph/s3-tests/pull/150

python2-pip doesn't exist in rhel and python-virtualenv ships pip in its package.

Signed-off-by: Vasu Kulkarni vasu@redhat.com