### PR TITLE
bootstrap: remove deprecated options to 'pip install'

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -35,8 +35,7 @@ virtualenv --no-site-packages --distribute virtualenv
 # work-around change in pip 1.5
 ./virtualenv/bin/pip install setuptools==32.3.1
 
-# Netifaces in non SSL external host.
-./virtualenv/bin/pip install --allow-unverified netifaces --allow-external netifaces -r requirements.txt
+./virtualenv/bin/pip install -r requirements.txt
 
 # forbid setuptools from using the network because it'll try to use
 # easy_install, and we really wanted pip; next line will fail if pip


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/23754